### PR TITLE
Update API domain

### DIFF
--- a/adhesive/glue.py
+++ b/adhesive/glue.py
@@ -292,7 +292,7 @@ def _img_to_png(image_data: bytes, thumbnail=False) -> bytes:
 async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token, test_mode=False):
 	metadata['test_mode'] = test_mode
 	r = await http.post(
-		'https://api.signalstickers.com/pack/propose',
+		'https://api-v1.signalstickers.com/pack/propose',
 		json=metadata,
 		headers={'X-Auth-Token': token},
 		timeout=60,


### PR DESCRIPTION
Signalstickers' API will change soon. In order to prepare the transition, Adhesive should use `api-v1.signalstickers.com` in place of `api.signalstickers.com`.
This is just an domain alias, so no other changes are required (for the moment :smiley: )