### PR TITLE
Use new API backend

### DIFF
--- a/adhesive/glue.py
+++ b/adhesive/glue.py
@@ -321,9 +321,9 @@ def _img_to_png(image_data: bytes, thumbnail=False) -> bytes:
 	del input
 	return out.getvalue()
 
-async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token):
+async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token, signalstickers_baseurl):
 	r = await http.put(
-		'https://api.signalstickers.com/v1/contribute/',
+		f'{signalstickers_baseurl}/v1/contribute/',
 		json={"pack": metadata},
 		headers={'X-Auth-Token': token},
 		timeout=60,

--- a/adhesive/glue.py
+++ b/adhesive/glue.py
@@ -321,11 +321,10 @@ def _img_to_png(image_data: bytes, thumbnail=False) -> bytes:
 	del input
 	return out.getvalue()
 
-async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token, test_mode=False):
-	metadata['test_mode'] = test_mode
-	r = await http.post(
-		'https://api-v1.signalstickers.com/pack/propose',
-		json=metadata,
+async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token):
+	r = await http.put(
+		'https://api.signalstickers.com/v1/contribute/',
+		json={"pack": metadata},
 		headers={'X-Auth-Token': token},
 		timeout=60,
 	)

--- a/adhesive/glue.py
+++ b/adhesive/glue.py
@@ -324,7 +324,7 @@ def _img_to_png(image_data: bytes, thumbnail=False) -> bytes:
 async def propose_to_signalstickers_dot_com(http, metadata: dict, *, token, signalstickers_baseurl):
 	r = await http.put(
 		f'{signalstickers_baseurl}/v1/contribute/',
-		json={"pack": metadata},
+		json=dict(pack=metadata),
 		headers={'X-Auth-Token': token},
 		timeout=60,
 	)

--- a/adhesive/telegram_bot.py
+++ b/adhesive/telegram_bot.py
@@ -127,7 +127,6 @@ async def maybe_enter_convo(event, is_link, response):
 			tags=[],
 			nsfw=False,
 			original=False,
-			animated=False,
 		)
 
 		# XXX instead of all this memory allocation,
@@ -220,25 +219,22 @@ async def maybe_enter_convo(event, is_link, response):
 			event.client.http,
 			meta,
 			token=event.client.config['signal']['stickers']['signalstickers_api_key'],
-			# TODO use configured log levels for this i guess
-			test_mode=event.client.config['signal']['stickers'].get('signalstickers_api_test_mode', False),
 		)
 
 		async with anyio.create_task_group() as tg:
 			await tg.spawn(partial(draft_msg.edit, buttons=None))
 			await tg.spawn(processing_message.delete)
 
-		if status_code not in range(200, 300):
+		if status_code != 200:
 			await event.reply(
 				"Ruh roh. Looks like we got an error from signalstickers.com. Here's what they said: "
 				f'“{data["error"]}”'
 			)
 		else:
 			await event.reply(
-				'Yuh, I submitted your pack to signalstickers.com. It will now be reviewed by a real meat-popsicle! '
-				f'Check it out here: {data["pr_url"]}\n'
-				'If you have a GitHub account you can comment on it there, '
-				"or if you don't, you can DM [@signalstickers on Twitter](https://twitter.com/signalstickers).",
+				"Yuh, I submitted your pack to signalstickers.com. It will now be reviewed by a real meat-popsicle! "
+				"[You can check its review status here](https://signalstickers.com/contribution-status).\n"
+				"If you have questions, DM [@signalstickers on Twitter](https://twitter.com/signalstickers).",
 				link_preview=False,
 			)
 

--- a/adhesive/telegram_bot.py
+++ b/adhesive/telegram_bot.py
@@ -228,19 +228,17 @@ async def maybe_enter_convo(event, is_link, response):
 			await tg.spawn(partial(draft_msg.edit, buttons=None))
 			await tg.spawn(processing_message.delete)
 
-		if 200 <= status_code < 300:
-			# TODO use the direct link to /contribution-status for the pack created
-			# when the feature is available on signalstickers.com
+		if status_code not in range(200, 300):
+			await event.reply(
+				"Ruh roh. Looks like we got an error from signalstickers.com. Here's what they said: "
+				f'“{data["error"]}”'
+			)
+		else:
 			await event.reply(
 				"Yuh, I submitted your pack to signalstickers.com. It will now be reviewed by a real meat-popsicle! "
 				"[You can check its review status here](https://signalstickers.com/contribution-status).\n"
 				"If you have questions, DM [@signalstickers on Twitter](https://twitter.com/signalstickers).",
 				link_preview=False,
-			)
-		else:
-			await event.reply(
-				"Ruh roh. Looks like we got an error from signalstickers.com. Here's what they said: "
-				f'“{data["error"]}”'
 			)
 
 async def answer(ev):

--- a/config.example.toml
+++ b/config.example.toml
@@ -38,5 +38,3 @@ password = '...'  # second password
 # This is optional. If present, a button to submit your converted Signal sticker pack
 # to signalstickers.com will be displayed.
 signalstickers_api_token = '...'
-# whether to really propose sticker packs for realsies or to create PR branches but no PRs
-signalstickers_api_test_mode = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -38,3 +38,7 @@ password = '...'  # second password
 # This is optional. If present, a button to submit your converted Signal sticker pack
 # to signalstickers.com will be displayed.
 signalstickers_api_token = '...'
+
+# The base url where signalstickers' API runs
+# Don't use trailing slash
+signalstickers_baseurl = 'https://api.signalstickers.com'


### PR DESCRIPTION
This PR modifies the `propose_to_signalstickers_dot_com` function (and its call),
to use the new API backend of signalstickers.com

⚠️ The API key must be updated to use the new backend