### PR TITLE
feat: Initialise SQLite database when starting bot

### DIFF
--- a/adhesive/bot.py
+++ b/adhesive/bot.py
@@ -17,7 +17,13 @@ You can also just send me a sticker and I'll convert the pack that it's from.
 This bot is open-source software under the terms of the AGPLv3 license. You can find the source code at:
 """
 
+DB_SCHEMA_PATH = './schema.sql'
+
 async def build_stickers_client(db, config):
+	if len(await db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")) == 0:
+		with open(DB_SCHEMA_PATH, 'r') as f:
+			await db.executescript(f.read())
+
 	accounts = {account['username']: account for account in config['signal']['stickers']['accounts']}
 	bucket_rows = await db.fetchall('SELECT account_id, space_remaining, last_updated_at FROM signal_accounts')
 	for row in bucket_rows:


### PR DESCRIPTION
There is no mention in the `README.md` the SQLite database has to be initialised.
This commits initialises the database as part of the initialisation of the sticker client.

## Tests

Starting the bot without a local `db.sqlite3` led to an error. When this patch is applied, it does not.

## Comments

This method could be wrapped in a different command if needed, but I don't know if this would be consistent with the rest of the codebase.